### PR TITLE
Restore YJIT memory limit to 48 MB to prevent OOM kills in aws-prod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   IMAGE_TAR_FILENAME: /tmp/${{ github.event.repository.name }}.${{ github.sha }}.tar
-  DOCKER_API_VERSION: ${{ vars.DOCKER_API_VERSION }}
 
 jobs:
   setup:

--- a/app/up.sh
+++ b/app/up.sh
@@ -8,7 +8,9 @@ if [ -z "${PORT:-}" ]; then
   exit 42
 fi
 
-export RUBYOPT='-W2'
+# Ruby 4.0 increased the default YJIT memory limit from 48MB to 128MB per process.
+# Without this, the service is OOM-killed in aws-prod. Restore the 3.3.x default.
+export RUBYOPT='-W2 --yjit-mem-size=48'
 
 puma \
   --port=${PORT} \


### PR DESCRIPTION
Ruby 4.0 raised the default YJIT memory limit from 48 MB to 128 MB per process. Under the new default the service is OOM-killed in production. Set --yjit-mem-size=48 in RUBYOPT to restore the Ruby 3.3.x behaviour.

Also removes the DOCKER_API_VERSION env var from the CI workflow, which is no longer needed.