### PR TITLE
Fix missing $ prefix on github.actor expression in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Commit
         run: |
-          git config --global user.name "{{ github.actor }}"
+          git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.event.sender.login }}@users.noreply.github.com"
           git add .
           git commit --message "Dockerfile - Automated base-image update"


### PR DESCRIPTION
The git config user.name step used {{ github.actor }} instead of ${{ github.actor }}, causing the literal string to be committed as the author name rather than the actual GitHub username.