### PR TITLE
Pass CI image between jobs via artifact, not cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,11 +53,13 @@ jobs:
           docker image save "${IMAGE_NAME}"
             --output="${IMAGE_TAR_FILENAME}"
 
-      - name: Cache Docker image
-        uses: actions/cache@v5
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v4
         with:
+          name: docker-image
           path: ${{ env.IMAGE_TAR_FILENAME }}
-          key:  ${{ env.IMAGE_NAME }}
+          retention-days: 1
+          if-no-files-found: error
 
 
   test-image:
@@ -66,11 +68,11 @@ jobs:
     env:
       IMAGE_NAME: ${{ needs.setup.outputs.image_name }}
     steps:
-      - name: Retrieve Docker image from cache
-        uses: actions/cache@v5
+      - name: Download Docker image
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ env.IMAGE_TAR_FILENAME }}
-          key:  ${{ env.IMAGE_NAME }}
+          name: docker-image
+          path: /tmp
 
       - name: Load Docker image
         run:
@@ -92,11 +94,11 @@ jobs:
     env:
       IMAGE_NAME: ${{ needs.setup.outputs.image_name }}
     steps:
-      - name: Retrieve Docker image from cache
-        uses: actions/cache@v5
+      - name: Download Docker image
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ env.IMAGE_TAR_FILENAME }}
-          key:  ${{ env.IMAGE_NAME }}
+          name: docker-image
+          path: /tmp
 
       - name: Load Docker image
         run:
@@ -133,11 +135,11 @@ jobs:
     steps:
       - uses: cyber-dojo/setup-kosli-cli@main
 
-      - name: Retrieve Docker image from cache
-        uses: actions/cache@v5
+      - name: Download Docker image
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ env.IMAGE_TAR_FILENAME }}
-          key:  ${{ env.IMAGE_NAME }}
+          name: docker-image
+          path: /tmp
 
       - name: Load Docker image
         run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cyber-dojo/sinatra-base:ac5f6a7@sha256:e74f2c4f8d2f8fa6504c7d044fd2ed6692c40a735c144d07e06cea38edfefccd AS base
+FROM ghcr.io/cyber-dojo/sinatra-base:1200d3b@sha256:7c4eb39e9b9de9b49f8fc650e47fac58bff984fe50198ab51d8fbdf623d4cc3f AS base
 # The FROM statement above is typically set via an automated pull-request from the sinatra-base repo
 LABEL maintainer=jon@jaggersoft.com
 


### PR DESCRIPTION
  actions/cache is meant for reuse across runs, not for handing a build
  output between jobs within one run. Two failure modes followed:

    - A failed cache restore is only a warning, so the restore step reported success (green check) while downloading nothing. The real failure surfaced one step later as a misleading "docker image load ... no such file or directory".
    - Cache downloads are best-effort. A single job hitting a transient ETIMEDOUT on GetCacheEntryDownloadURL failed the whole workflow even though the entry existed and other jobs restored it fine in the same run (see run 28580191384).

  Switch to upload-artifact/download-artifact, the intended mechanism for
  passing files between jobs in a run: a missing download fails loudly with
  a clear message, and the artifact is scoped to the run. download-artifact
  restores the tar to the same IMAGE_TAR_FILENAME path, so the
  docker image load steps are unchanged.