### PR TITLE
Bump artifact actions to node24 majors to clear deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
             --output="${IMAGE_TAR_FILENAME}"
 
       - name: Upload Docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-image
           path: ${{ env.IMAGE_TAR_FILENAME }}
@@ -69,7 +69,7 @@ jobs:
       IMAGE_NAME: ${{ needs.setup.outputs.image_name }}
     steps:
       - name: Download Docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-image
           path: /tmp
@@ -95,7 +95,7 @@ jobs:
       IMAGE_NAME: ${{ needs.setup.outputs.image_name }}
     steps:
       - name: Download Docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-image
           path: /tmp
@@ -136,7 +136,7 @@ jobs:
       - uses: cyber-dojo/setup-kosli-cli@main
 
       - name: Download Docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-image
           path: /tmp


### PR DESCRIPTION
  GitHub deprecated the Node 20 runtime on its runners, so it force-runs
  actions/upload-artifact@v4 and actions/download-artifact@v4 (both Node 20)
  on Node 24 and emits a deprecation warning on every CI run.

  Move to the current majors, which declare runs.using: node24:
    upload-artifact  v4 -> v7
    download-artifact v4 -> v8

  The workflow uploads and downloads the image tar within the same run, so
  the v4/v5 artifact incompatibility does not affect us.